### PR TITLE
Add OAuth2 security setup for auth-service

### DIFF
--- a/auth-service/build.gradle.kts
+++ b/auth-service/build.gradle.kts
@@ -8,6 +8,9 @@ plugins {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-authorization-server")
+    implementation("com.nimbusds:nimbus-jose-jwt:9.37")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation(project(":common-lib"))

--- a/auth-service/src/main/kotlin/com/example/auth/service/CustomUserDetailsService.kt
+++ b/auth-service/src/main/kotlin/com/example/auth/service/CustomUserDetailsService.kt
@@ -1,0 +1,23 @@
+package com.example.auth.service
+
+import org.springframework.security.core.userdetails.User
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.stereotype.Service
+
+/**
+ * Simple [UserDetailsService] implementation used for demonstration purposes.
+ * In a real application this would query a user repository or external service.
+ */
+@Service
+class CustomUserDetailsService : UserDetailsService {
+
+    override fun loadUserByUsername(username: String): UserDetails {
+        // Returns a dummy user. Password uses {noop} encoder for simplicity.
+        return User.withUsername(username)
+            .password("{noop}password")
+            .roles("USER")
+            .build()
+    }
+}
+

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -1,3 +1,9 @@
 spring:
   application:
     name: auth-service
+  security:
+    oauth2:
+      authorization:
+        issuer-uri: http://localhost:8081
+server:
+  port: 8081


### PR DESCRIPTION
## Summary
- add security dependencies to `auth-service`
- configure oauth2 issuer and port in `application.yml`
- implement `CustomUserDetailsService`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d835abf9083208b701eef05974f0b