### PR TITLE
Enable Eureka service discovery

### DIFF
--- a/auth-service/build.gradle.kts
+++ b/auth-service/build.gradle.kts
@@ -5,9 +5,16 @@ plugins {
     kotlin("plugin.spring")
 }
 
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2022.0.5")
+    }
+}
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-authorization-server")
     implementation("com.nimbusds:nimbus-jose-jwt:9.37")

--- a/auth-service/src/main/kotlin/com/example/auth/service/HelloController.kt
+++ b/auth-service/src/main/kotlin/com/example/auth/service/HelloController.kt
@@ -7,4 +7,7 @@ import org.springframework.web.bind.annotation.RestController
 class HelloController {
     @GetMapping("/hello")
     fun hello() = "Hello from auth-service"
+
+    @GetMapping("/auth/check")
+    fun check() = "Auth service is running"
 }

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -5,5 +5,9 @@ spring:
     oauth2:
       authorization:
         issuer-uri: http://localhost:8081
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka
 server:
   port: 8081

--- a/discovery-server/build.gradle.kts
+++ b/discovery-server/build.gradle.kts
@@ -5,9 +5,16 @@ plugins {
     kotlin("plugin.spring")
 }
 
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2022.0.5")
+    }
+}
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-server")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation(project(":common-lib"))

--- a/discovery-server/src/main/kotlin/com/example/discovery/server/MainApplication.kt
+++ b/discovery-server/src/main/kotlin/com/example/discovery/server/MainApplication.kt
@@ -2,8 +2,10 @@ package com.example.discovery.server
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer
 
 @SpringBootApplication
+@EnableEurekaServer
 class DiscoveryServerApplication
 
 fun main(args: Array<String>) {

--- a/discovery-server/src/main/resources/application.yml
+++ b/discovery-server/src/main/resources/application.yml
@@ -1,3 +1,9 @@
+server:
+  port: 8761
 spring:
   application:
     name: discovery-server
+eureka:
+  client:
+    register-with-eureka: false
+    fetch-registry: false

--- a/gateway-service/build.gradle.kts
+++ b/gateway-service/build.gradle.kts
@@ -24,5 +24,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.cloud:spring-cloud-starter-gateway")
+    implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
     gateway:
       routes:
         - id: user-service
-          uri: http://localhost:8082
+          uri: lb://user-service
           predicates:
             - Path=/api/user/**
           filters:
@@ -21,6 +21,10 @@ spring:
       resourceserver:
         jwt:
           jwk-set-uri: http://localhost:8081/oauth2/jwks
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka
 logging:
   level:
     org.springframework.cloud.gateway: DEBUG

--- a/user-service/build.gradle.kts
+++ b/user-service/build.gradle.kts
@@ -5,9 +5,16 @@ plugins {
     kotlin("plugin.spring")
 }
 
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2022.0.5")
+    }
+}
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation(project(":common-lib"))

--- a/user-service/src/main/kotlin/com/example/user/service/TestController.kt
+++ b/user-service/src/main/kotlin/com/example/user/service/TestController.kt
@@ -1,0 +1,22 @@
+package com.example.user.service
+
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.client.RestTemplate
+
+@RestController
+class TestController(private val restTemplate: RestTemplate) {
+
+    @GetMapping("/test-auth")
+    fun testAuth(): ResponseEntity<String> {
+        val response = restTemplate.getForEntity("http://auth-service/auth/check", String::class.java)
+        return response
+    }
+
+    @Bean
+    fun restTemplate(builder: RestTemplateBuilder): RestTemplate =
+        builder.build()
+}

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -1,5 +1,9 @@
 spring:
   application:
     name: user-service
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka
 server:
   port: 8082


### PR DESCRIPTION
## Summary
- set up discovery-server as a Eureka server
- configure gateway-service, auth-service and user-service as Eureka clients
- route gateway user-service calls through Eureka
- add a simple /auth/check endpoint
- add TestController in user-service that calls auth-service via Eureka

## Testing
- `./gradlew test` *(fails: Plugin not found due to offline env)*

------
https://chatgpt.com/codex/tasks/task_e_6850a1d4cd6c83208459423b719f7b6e